### PR TITLE
Improve installation: Use /usr/local/bin & simplify manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ cargo install rascii_art
 > GNU/Linux or any other POSIX compatible systems!
 
 ```sh
-git clone https://github.com/KoBruhh/RASCII && cd RASCII
-chmod +x install.sh
-./install.sh
+curl -sL https://raw.githubusercontent.com/orhnk/RASCII/refs/heads/master/install.sh | sh
 ```
 
 ## Using The Crate

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,9 @@
 echo "Sudo is needed to copy the binary to /usr/local/bin - prompting now."
 sudo true
 
+git clone https://github.com/orhnk/RASCII
+cd RASCII
+
 cargo build --release
 
 sudo cp ./target/release/rascii /usr/local/bin

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ echo "Sudo is needed to copy the binary to /usr/local/bin - prompting now."
 sudo true
 
 git clone https://github.com/orhnk/RASCII
+
 cd RASCII
 
 cargo build --release

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,15 @@
 echo "Sudo is needed to copy the binary to /usr/local/bin - prompting now."
 sudo true
 
-git clone https://github.com/orhnk/RASCII
+if [ -d "RASCII" ]; then
+    echo "Error: RASCII directory already exists"
+    exit 1
+fi
+
+if ! git clone https://github.com/orhnk/RASCII; then
+    echo "Error: Failed to clone RASCII repository"
+    exit 1
+fi
 
 cd RASCII
 

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-echo "Sudo is needed to copy the binary to /usr/bin - prompting now."
+echo "Sudo is needed to copy the binary to /usr/local/bin - prompting now."
 sudo true
 
 cargo build --release
 
-sudo cp ./target/release/rascii /usr/bin
+sudo cp ./target/release/rascii /usr/local/bin
 
 echo "RASCII has been successfully installed on your system. You can run
 


### PR DESCRIPTION
### **Description:**  
This PR improves the installation process by:  
1. **Using `/usr/local/bin` instead of `/usr/bin`**  
   - `/usr/local/bin` is the recommended location for user-installed binaries.  
   - Avoids potential conflicts with system-managed packages.  

2. **Simplifying manual installation in the README**  
   - Instead of manually cloning, navigating, and running `chmod +x`, users can now install with a single command:  
     ```sh
     curl -sL https://raw.githubusercontent.com/orhnk/RASCII/refs/heads/master/install.sh | sh
     ```  
   - This makes installation faster and easier for users.  

These changes follow best practices and improve the user experience.

## Summary by Sourcery

Update the installation script to install the binary to `/usr/local/bin` instead of `/usr/bin`. Simplify the manual installation instructions in the README to a single command.

Enhancements:
- Use `/usr/local/bin` for binary installation, which is the standard location for user-installed executables and prevents conflicts with system packages.
- Simplify manual installation with a single `curl` command that clones the repository, builds the binary, and installs it.