### PR TITLE
feat: add charsets, --trim, animations, and GIF playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 !src/
 !src/render/
+!tests/
 
 !.gitignore
 !Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "ansi_term",
  "clap",
  "image",
+ "rand",
  "unicode-segmentation",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 edition = "2021"
 
 [dependencies]
+rand = "0.8"
 ansi_term = "0.12.1"
 clap = { version = "4.5.31", features = ["derive"] }
 image = "0.25.5"

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -13,6 +13,8 @@ pub enum Effect {
     DissolveOut,
     SwirlIn,
     SwirlOut,
+    WhirlIn,
+    WhirlOut,
     KenBurns,
 }
 
@@ -23,6 +25,8 @@ impl Effect {
             "dissolve-out" => Some(Self::DissolveOut),
             "swirl-in" => Some(Self::SwirlIn),
             "swirl-out" => Some(Self::SwirlOut),
+            "whirl-in" => Some(Self::WhirlIn),
+            "whirl-out" => Some(Self::WhirlOut),
             "ken-burns" => Some(Self::KenBurns),
             _ => None,
         }
@@ -54,6 +58,8 @@ impl Animator {
             Effect::DissolveOut => self.play_dissolve_out(&mut out)?,
             Effect::SwirlIn => self.play_swirl(&mut out, false)?,
             Effect::SwirlOut => self.play_swirl(&mut out, true)?,
+            Effect::WhirlIn => self.play_whirl(&mut out, false)?,
+            Effect::WhirlOut => self.play_whirl(&mut out, true)?,
             Effect::KenBurns => self.play_ken_burns(&mut out)?,
         }
 
@@ -195,6 +201,51 @@ impl Animator {
     fn play_swirl(&self, out: &mut impl Write, from_center: bool) -> io::Result<()> {
         let mut positions = self.spiral_positions();
         if from_center {
+            positions.reverse();
+        }
+        self.play_batched(out, &positions, true)
+    }
+
+    fn whirl_positions(&self) -> Vec<(usize, usize)> {
+        let rows = self.grid.len();
+        if rows == 0 {
+            return Vec::new();
+        }
+        let cols = self.grid[0].len();
+        if cols == 0 {
+            return Vec::new();
+        }
+
+        let center_r = rows as f64 / 2.0;
+        let center_c = cols as f64 / 2.0;
+        let max_radius = (center_r * center_r + center_c * center_c).sqrt();
+        // Number of full rotations from center to edge
+        let num_rotations = 4.0;
+
+        let mut positions: Vec<(f64, usize, usize)> = Vec::with_capacity(rows * cols);
+        for r in 0..rows {
+            for c in 0..cols {
+                let dr = r as f64 - center_r;
+                let dc = c as f64 - center_c;
+                let radius = (dr * dr + dc * dc).sqrt();
+                let angle = dr.atan2(dc); // -PI..PI
+                let normalized_radius = radius / max_radius;
+                // Angle normalized to 0..1
+                let angle_norm = (angle + std::f64::consts::PI) / (2.0 * std::f64::consts::PI);
+                // Radius is the primary sort; angle creates a spin within each ring band.
+                // Each 1/num_rotations band of radius gets one full angular sweep.
+                let key = normalized_radius + angle_norm / num_rotations;
+                positions.push((key, r, c));
+            }
+        }
+        positions.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        positions.into_iter().map(|(_, r, c)| (r, c)).collect()
+    }
+
+    fn play_whirl(&self, out: &mut impl Write, outward: bool) -> io::Result<()> {
+        let mut positions = self.whirl_positions();
+        if !outward {
+            // whirl-in: edge first, center last
             positions.reverse();
         }
         self.play_batched(out, &positions, true)

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -1,0 +1,253 @@
+use std::io::{self, Write};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+
+use crate::cell::Grid;
+
+#[derive(Clone, Debug)]
+pub enum Effect {
+    DissolveIn,
+    DissolveOut,
+    SwirlIn,
+    SwirlOut,
+    KenBurns,
+}
+
+impl Effect {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "dissolve-in" => Some(Self::DissolveIn),
+            "dissolve-out" => Some(Self::DissolveOut),
+            "swirl-in" => Some(Self::SwirlIn),
+            "swirl-out" => Some(Self::SwirlOut),
+            "ken-burns" => Some(Self::KenBurns),
+            _ => None,
+        }
+    }
+}
+
+pub struct Animator {
+    grid: Grid,
+    effect: Effect,
+    duration: Duration,
+}
+
+impl Animator {
+    pub fn new(grid: Grid, effect: Effect, duration_secs: f64) -> Self {
+        Self {
+            grid,
+            effect,
+            duration: Duration::from_secs_f64(duration_secs),
+        }
+    }
+
+    pub fn play(&self) -> io::Result<()> {
+        let mut out = io::stdout();
+        write!(out, "\x1b[?25l\x1b[2J")?;
+        out.flush()?;
+
+        match self.effect {
+            Effect::DissolveIn => self.play_dissolve_in(&mut out)?,
+            Effect::DissolveOut => self.play_dissolve_out(&mut out)?,
+            Effect::SwirlIn => self.play_swirl(&mut out, false)?,
+            Effect::SwirlOut => self.play_swirl(&mut out, true)?,
+            Effect::KenBurns => self.play_ken_burns(&mut out)?,
+        }
+
+        write!(out, "\x1b[?25h")?;
+        out.flush()?;
+        Ok(())
+    }
+
+    fn all_positions(&self) -> Vec<(usize, usize)> {
+        let mut positions = Vec::new();
+        for (r, row) in self.grid.iter().enumerate() {
+            for (c, _) in row.iter().enumerate() {
+                positions.push((r, c));
+            }
+        }
+        positions
+    }
+
+    fn draw_cell(&self, out: &mut impl Write, row: usize, col: usize) -> io::Result<()> {
+        let cell = &self.grid[row][col];
+        write!(
+            out,
+            "\x1b[{};{}H{}{}{}",
+            row + 1,
+            col + 1,
+            cell.color_pre,
+            cell.ch,
+            cell.color_suf
+        )
+    }
+
+    fn clear_cell(&self, out: &mut impl Write, row: usize, col: usize) -> io::Result<()> {
+        write!(out, "\x1b[{};{}H ", row + 1, col + 1)
+    }
+
+    fn draw_full(&self, out: &mut impl Write) -> io::Result<()> {
+        for (r, row) in self.grid.iter().enumerate() {
+            for (c, _) in row.iter().enumerate() {
+                self.draw_cell(out, r, c)?;
+            }
+        }
+        out.flush()
+    }
+
+    fn play_dissolve_in(&self, out: &mut impl Write) -> io::Result<()> {
+        let mut positions = self.all_positions();
+        positions.shuffle(&mut thread_rng());
+        self.play_batched(out, &positions, true)
+    }
+
+    fn play_dissolve_out(&self, out: &mut impl Write) -> io::Result<()> {
+        self.draw_full(out)?;
+        thread::sleep(Duration::from_millis(500));
+        let mut positions = self.all_positions();
+        positions.shuffle(&mut thread_rng());
+        self.play_batched(out, &positions, false)?;
+        thread::sleep(Duration::from_millis(300));
+        self.draw_full(out)?;
+        Ok(())
+    }
+
+    fn play_batched(
+        &self,
+        out: &mut impl Write,
+        positions: &[(usize, usize)],
+        reveal: bool,
+    ) -> io::Result<()> {
+        let total = positions.len();
+        if total == 0 {
+            return Ok(());
+        }
+        let target_fps = 30.0;
+        let total_frames = (self.duration.as_secs_f64() * target_fps) as usize;
+        let cells_per_frame = (total as f64 / total_frames.max(1) as f64).ceil() as usize;
+        let frame_duration = self.duration / total_frames.max(1) as u32;
+        let start = Instant::now();
+
+        for (i, chunk) in positions.chunks(cells_per_frame.max(1)).enumerate() {
+            for &(r, c) in chunk {
+                if reveal {
+                    self.draw_cell(out, r, c)?;
+                } else {
+                    self.clear_cell(out, r, c)?;
+                }
+            }
+            out.flush()?;
+            let target_time = frame_duration * (i + 1) as u32;
+            let elapsed = start.elapsed();
+            if elapsed < target_time {
+                thread::sleep(target_time - elapsed);
+            }
+        }
+
+        if reveal {
+            self.draw_full(out)?;
+        }
+        Ok(())
+    }
+
+    fn spiral_positions(&self) -> Vec<(usize, usize)> {
+        let rows = self.grid.len();
+        if rows == 0 {
+            return Vec::new();
+        }
+        let cols = self.grid[0].len();
+        if cols == 0 {
+            return Vec::new();
+        }
+
+        let mut positions = Vec::with_capacity(rows * cols);
+        let (mut top, mut bottom, mut left, mut right) =
+            (0i32, rows as i32 - 1, 0i32, cols as i32 - 1);
+
+        while top <= bottom && left <= right {
+            for c in left..=right {
+                positions.push((top as usize, c as usize));
+            }
+            top += 1;
+            for r in top..=bottom {
+                positions.push((r as usize, right as usize));
+            }
+            right -= 1;
+            if top <= bottom {
+                for c in (left..=right).rev() {
+                    positions.push((bottom as usize, c as usize));
+                }
+                bottom -= 1;
+            }
+            if left <= right {
+                for r in (top..=bottom).rev() {
+                    positions.push((r as usize, left as usize));
+                }
+                left += 1;
+            }
+        }
+        positions
+    }
+
+    fn play_swirl(&self, out: &mut impl Write, from_center: bool) -> io::Result<()> {
+        let mut positions = self.spiral_positions();
+        if from_center {
+            positions.reverse();
+        }
+        self.play_batched(out, &positions, true)
+    }
+
+    fn play_ken_burns(&self, out: &mut impl Write) -> io::Result<()> {
+        let rows = self.grid.len();
+        if rows == 0 {
+            return Ok(());
+        }
+        let cols = self.grid[0].len();
+
+        // If grid is small, just show full image
+        if rows <= 1 || cols <= 1 {
+            self.draw_full(out)?;
+            thread::sleep(self.duration);
+            return Ok(());
+        }
+
+        let target_fps = 24.0;
+        let total_frames = (self.duration.as_secs_f64() * target_fps) as usize;
+        let frame_duration = self.duration / total_frames.max(1) as u32;
+        let start = Instant::now();
+
+        for frame in 0..total_frames {
+            let t = frame as f64 / total_frames.max(1) as f64;
+
+            // Pan from top-left to bottom-right
+            let view_y = ((rows.saturating_sub(rows)) as f64 * t) as usize;
+            let view_x = ((cols.saturating_sub(cols)) as f64 * t) as usize;
+
+            write!(out, "\x1b[H")?;
+            for r in 0..rows.min(rows - view_y) {
+                let grid_row = &self.grid[view_y + r];
+                for c in 0..cols.min(cols - view_x) {
+                    let cell = &grid_row[view_x + c];
+                    write!(out, "{}{}{}", cell.color_pre, cell.ch, cell.color_suf)?;
+                }
+                if r < rows - 1 {
+                    writeln!(out)?;
+                }
+            }
+            out.flush()?;
+
+            let target_time = frame_duration * (frame + 1) as u32;
+            let elapsed = start.elapsed();
+            if elapsed < target_time {
+                thread::sleep(target_time - elapsed);
+            }
+        }
+
+        write!(out, "\x1b[2J")?;
+        self.draw_full(out)?;
+        Ok(())
+    }
+}

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,0 +1,8 @@
+#[derive(Clone, Debug)]
+pub struct Cell {
+    pub ch: String,
+    pub color_pre: String,
+    pub color_suf: String,
+}
+
+pub type Grid = Vec<Vec<Cell>>;

--- a/src/charsets.rs
+++ b/src/charsets.rs
@@ -1,4 +1,14 @@
 pub const BLOCK: &[&str] = &[" ", "░", "▒", "▓", "█"];
+pub const BLOCKS: &[&str] = &[
+    " ", "▏", "▁", "▎", "▂", "▍", "▃", "▌", "▄", "▋", "▅", "▊", "▆", "▉", "▇", "█",
+];
+pub const BRAILLE: &[&str] = &["⠀", "⠁", "⠉", "⠋", "⠛", "⠟", "⠿", "⡿", "⣿"];
+pub const HYBRID: &[&str] = &[
+    // Braille: fine dot patterns for the light range (~0-20% fill)
+    "⠀", "⠁", "⠉", "⠋", "⠛", "⠟", "⠿", "⡿", "⣿",
+    // Blocks: solid fills for the dark range (~25-100% fill)
+    "░", "▍", "▒", "▋", "▓", "▉", "█",
+];
 pub const CHINESE: &[&str] = &[
     "\u{3000}", "一", "二", "十", "人", "丁", "口", "王", "日", "木", "金", "華", "爱", "黑", "墨",
     "龍", "龘",
@@ -8,6 +18,13 @@ pub const DEFAULT: &[&str] = &[
     "-", "?", "]", "[", "}", "{", "1", ")", "(", "|", "\\", "/", "t", "f", "j", "r", "x", "n", "u",
     "v", "c", "z", "X", "Y", "U", "J", "C", "L", "Q", "0", "O", "Z", "m", "w", "q", "p", "d", "b",
     "k", "h", "a", "o", "*", "#", "M", "W", "&", "8", "%", "B", "$", "@",
+];
+pub const DENSE: &[&str] = &[
+    " ", ".", "`", "'", "^", "\"", ",", ":", ";", "-", "~", "=", "_", "+", "<", ">", "!", "|", "I",
+    "l", "1", "i", "\\", "/", "(", ")", "{", "}", "[", "]", "?", "r", "c", "t", "f", "j", "7", "v",
+    "n", "u", "z", "x", "s", "J", "L", "T", "*", "e", "k", "a", "o", "y", "p", "q", "w", "C", "S",
+    "U", "d", "h", "b", "3", "9", "2", "6", "4", "5", "0", "Z", "E", "F", "P", "g", "V", "Y", "A",
+    "H", "K", "X", "D", "m", "O", "R", "G", "#", "N", "Q", "8", "B", "W", "M", "%", "&", "@", "$",
 ];
 pub const EMOJI: &[&str] = &[
     "\u{3000}", "\u{3000}", "。", "，", "🧔", "👶", "🗣", "👥", "👤", "👀", "👁", "🦴", "🦷", "🫁",
@@ -25,15 +42,23 @@ pub const SLIGHT: &[&str] = &[
     " ", " ", ".", "`", "\"", "\\", ":", "I", "!", ">", "~", "_", "?", "[", "{", "|", ")", "(",
     "\\", "\\\\", "/", "Y", "L", "p", "d", "a", "*", "W", "8", "%", "@", "$",
 ];
+pub const STIPPLE: &[&str] = &[
+    " ", ".", "·", ":", "*", "+", "o", "O", "0", "#", "8", "%", "@", "$",
+];
 
 pub fn from_str(s: &str) -> Option<&[&str]> {
     match s {
         "block" => Some(BLOCK),
+        "blocks" => Some(BLOCKS),
+        "braille" => Some(BRAILLE),
         "chinese" => Some(CHINESE),
         "default" => Some(DEFAULT),
+        "dense" => Some(DENSE),
+        "hybrid" => Some(HYBRID),
         "emoji" => Some(EMOJI),
         "russian" => Some(RUSSIAN),
         "slight" => Some(SLIGHT),
+        "stipple" => Some(STIPPLE),
         _ => None,
     }
 }

--- a/src/gif_renderer.rs
+++ b/src/gif_renderer.rs
@@ -1,1 +1,68 @@
+use std::fs::File;
+use std::io::{self, BufReader, Write};
+use std::thread;
+use std::time::Duration;
 
+use image::codecs::gif::GifDecoder;
+use image::{AnimationDecoder, DynamicImage};
+
+use crate::cell::Grid;
+use crate::image_renderer::ImageRenderer;
+use crate::renderer::{RenderOptions, Renderer};
+
+pub struct GifRenderer;
+
+impl GifRenderer {
+    pub fn play(path: &str, options: &RenderOptions<'_>) -> io::Result<()> {
+        let file = File::open(path).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let decoder = GifDecoder::new(BufReader::new(file))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let frames: Vec<_> = decoder
+            .into_frames()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        if frames.is_empty() {
+            return Ok(());
+        }
+
+        let mut out = io::stdout();
+        write!(out, "\x1b[?25l\x1b[2J")?;
+        out.flush()?;
+
+        // Pre-render all frames to grids
+        let grids: Vec<(Grid, Duration)> = frames
+            .iter()
+            .map(|frame| {
+                let (numer, denom) = frame.delay().numer_denom_ms();
+                let delay = Duration::from_millis((numer as u64) / (denom as u64).max(1));
+                let image = DynamicImage::ImageRgba8(frame.buffer().clone());
+                let image = if options.trim {
+                    crate::trim::trim_image(&image)
+                } else {
+                    image
+                };
+                let renderer = ImageRenderer::new(&image, options);
+                let grid = renderer.render_grid();
+                (grid, delay)
+            })
+            .collect();
+
+        // Play loop — Ctrl-C to stop
+        loop {
+            for (grid, delay) in &grids {
+                write!(out, "\x1b[H")?;
+                for (r, row) in grid.iter().enumerate() {
+                    for cell in row {
+                        write!(out, "{}{}{}", cell.color_pre, cell.ch, cell.color_suf)?;
+                    }
+                    if r < grid.len() - 1 {
+                        writeln!(out)?;
+                    }
+                }
+                out.flush()?;
+                thread::sleep(*delay);
+            }
+        }
+    }
+}

--- a/src/image_renderer.rs
+++ b/src/image_renderer.rs
@@ -1,18 +1,9 @@
 use std::io;
 
-use ansi_term::{
-    Color,
-    Style,
-};
-use image::{
-    DynamicImage,
-    Rgba,
-};
+use ansi_term::{Color, Style};
+use image::{DynamicImage, Rgba};
 
-use super::renderer::{
-    RenderOptions,
-    Renderer,
-};
+use super::renderer::{RenderOptions, Renderer};
 
 pub struct ImageRenderer<'a> {
     resource: &'a DynamicImage,
@@ -35,6 +26,72 @@ impl ImageRenderer<'_> {
 
     fn get_grayscale(&self, pixel: &Rgba<u8>) -> f64 {
         ((pixel[0] as f64 * 0.299) + (pixel[1] as f64 * 0.587) + (pixel[2] as f64 * 0.114)) / 255.0
+    }
+
+    pub fn render_grid(&self) -> crate::cell::Grid {
+        let (width, height) = (
+            self.options.width.unwrap_or_else(|| {
+                (self
+                    .options
+                    .height
+                    .expect("Either width or height must be set") as f64
+                    * (self.resource.width() as f64 / self.resource.height() as f64)
+                    * 2.0)
+                    .ceil() as u32
+            }),
+            self.options.height.unwrap_or_else(|| {
+                (self
+                    .options
+                    .width
+                    .expect("Either width or height must be set") as f64
+                    * (self.resource.height() as f64 / self.resource.width() as f64)
+                    / 2.0)
+                    .ceil() as u32
+            }),
+        );
+
+        let image = self.resource.thumbnail_exact(width, height).to_rgba8();
+        let maximum = image
+            .pixels()
+            .fold(0.0, |acc, pixel| self.get_grayscale(pixel).max(acc));
+
+        let mut grid: crate::cell::Grid = Vec::new();
+        let mut current_row: Vec<crate::cell::Cell> = Vec::new();
+        let mut prev_line = 0;
+
+        for (_, line, pixel) in image.enumerate_pixels() {
+            if prev_line < line {
+                prev_line = line;
+                grid.push(current_row);
+                current_row = Vec::new();
+            }
+
+            let ch = self.get_char_for_pixel(pixel, maximum).to_string();
+
+            let (color_pre, color_suf) = if self.options.colored || self.options.background {
+                let mut style = ansi_term::Style::new();
+                if self.options.colored {
+                    style = style.fg(ansi_term::Color::RGB(pixel[0], pixel[1], pixel[2]));
+                }
+                if self.options.background {
+                    style = style.on(ansi_term::Color::RGB(pixel[0], pixel[1], pixel[2]));
+                }
+                (style.prefix().to_string(), style.suffix().to_string())
+            } else {
+                (String::new(), String::new())
+            };
+
+            current_row.push(crate::cell::Cell {
+                ch,
+                color_pre,
+                color_suf,
+            });
+        }
+        if !current_row.is_empty() {
+            grid.push(current_row);
+        }
+
+        grid
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! }
 //! ```
 
+pub mod cell;
 pub mod charsets;
 
 mod gif_renderer;
@@ -80,6 +81,11 @@ pub fn render_to<P: AsRef<Path> + AsRef<str>>(
     let renderer = ImageRenderer::new(&image, options);
     renderer.render(buffer)?;
     Ok(())
+}
+
+pub fn render_grid(image: &DynamicImage, options: &RenderOptions<'_>) -> cell::Grid {
+    let renderer = ImageRenderer::new(image, options);
+    renderer.render_grid()
 }
 
 pub fn render_image_to(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub mod animator;
 pub mod cell;
 pub mod charsets;
 
-mod gif_renderer;
-mod image_renderer;
+pub(crate) mod gif_renderer;
+pub(crate) mod image_renderer;
 mod renderer;
 pub(crate) mod trim;
 
@@ -34,6 +34,10 @@ use image_renderer::ImageRenderer;
 pub use renderer::RenderOptions;
 use renderer::Renderer;
 use std::{io, path::Path};
+
+pub fn render_gif(path: &str, options: &RenderOptions<'_>) -> io::Result<()> {
+    gif_renderer::GifRenderer::play(path, options)
+}
 
 pub use trim::trim_image;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod charsets;
 mod gif_renderer;
 mod image_renderer;
 mod renderer;
+pub(crate) mod trim;
 
 use image::DynamicImage;
 use image_renderer::ImageRenderer;
@@ -32,13 +33,20 @@ pub use renderer::RenderOptions;
 use renderer::Renderer;
 use std::{io, path::Path};
 
+pub use trim::trim_image;
+
 pub fn render<P: AsRef<Path> + AsRef<str>>(
     path: P,
     to: &mut impl io::Write,
     options: &RenderOptions<'_>,
 ) -> image::ImageResult<()> {
-    let image = &image::open(path)?;
-    render_image(image, to, options)
+    let image = image::open(path)?;
+    let image = if options.trim {
+        trim::trim_image(&image)
+    } else {
+        image
+    };
+    render_image(&image, to, options)
 }
 
 pub fn render_image(
@@ -46,7 +54,14 @@ pub fn render_image(
     to: &mut impl io::Write,
     options: &RenderOptions<'_>,
 ) -> image::ImageResult<()> {
-    let renderer = ImageRenderer::new(image, options);
+    let owned;
+    let img = if options.trim {
+        owned = trim::trim_image(image);
+        &owned
+    } else {
+        image
+    };
+    let renderer = ImageRenderer::new(img, options);
     renderer.render_to(to)?;
     Ok(())
 }
@@ -56,8 +71,13 @@ pub fn render_to<P: AsRef<Path> + AsRef<str>>(
     buffer: &mut String,
     options: &RenderOptions<'_>,
 ) -> image::ImageResult<()> {
-    let image = &image::open(path)?;
-    let renderer = ImageRenderer::new(image, options);
+    let image = image::open(path)?;
+    let image = if options.trim {
+        trim::trim_image(&image)
+    } else {
+        image
+    };
+    let renderer = ImageRenderer::new(&image, options);
     renderer.render(buffer)?;
     Ok(())
 }
@@ -67,7 +87,14 @@ pub fn render_image_to(
     buffer: &mut String,
     options: &RenderOptions<'_>,
 ) -> image::ImageResult<()> {
-    let renderer = ImageRenderer::new(image, options);
+    let owned;
+    let img = if options.trim {
+        owned = trim::trim_image(image);
+        &owned
+    } else {
+        image
+    };
+    let renderer = ImageRenderer::new(img, options);
     renderer.render(buffer)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! }
 //! ```
 
+pub mod animator;
 pub mod cell;
 pub mod charsets;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use clap::Parser;
-use rascii_art::{charsets, RenderOptions};
+use rascii_art::{animator, charsets, RenderOptions};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Parser)]
@@ -41,6 +41,15 @@ struct Args {
     /// emoji, hybrid, russian, slight, stipple
     #[arg(short = 'C', long, default_value = "default")]
     charset: String,
+
+    /// Animate the output with a terminal effect.
+    /// Effects: dissolve-in, dissolve-out, swirl-in, swirl-out, ken-burns
+    #[arg(short = 'a', long)]
+    animate: Option<String>,
+
+    /// Duration of the animation in seconds
+    #[arg(short = 'd', long, default_value = "3.0")]
+    duration: f64,
 }
 
 fn main() -> image::ImageResult<()> {
@@ -53,19 +62,46 @@ fn main() -> image::ImageResult<()> {
         args.width = Some(80);
     }
 
-    rascii_art::render(
-        &args.filename,
-        &mut io::stdout(),
-        &RenderOptions {
-            width: args.width,
-            height: args.height,
-            colored: args.colored,
-            background: args.background,
-            invert: args.invert,
-            trim: args.trim,
-            charset,
-        },
-    )?;
+    let options = RenderOptions {
+        width: args.width,
+        height: args.height,
+        colored: args.colored,
+        background: args.background,
+        invert: args.invert,
+        trim: args.trim,
+        charset,
+    };
+
+    // Check if input is an animated GIF
+    if args.filename.to_lowercase().ends_with(".gif") {
+        rascii_art::render_gif(&args.filename, &options).map_err(image::ImageError::IoError)?;
+        return Ok(());
+    }
+
+    // Check for animation effect
+    if let Some(ref effect_name) = args.animate {
+        let effect = animator::Effect::from_str(effect_name).unwrap_or_else(|| {
+            eprintln!(
+                "Unknown animation effect: {}. Valid: dissolve-in, dissolve-out, swirl-in, swirl-out, ken-burns",
+                effect_name
+            );
+            std::process::exit(1);
+        });
+
+        let image = image::open(&args.filename)?;
+        let image = if args.trim {
+            rascii_art::trim_image(&image)
+        } else {
+            image
+        };
+        let grid = rascii_art::render_grid(&image, &options);
+        let anim = animator::Animator::new(grid, effect, args.duration);
+        anim.play().map_err(image::ImageError::IoError)?;
+        return Ok(());
+    }
+
+    // Static render
+    rascii_art::render(&args.filename, &mut io::stdout(), &options)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,8 @@ struct Args {
     charset: String,
 
     /// Animate the output with a terminal effect.
-    /// Effects: dissolve-in, dissolve-out, swirl-in, swirl-out, ken-burns
+    /// Effects: dissolve-in, dissolve-out, swirl-in, swirl-out, whirl-in,
+    /// whirl-out, ken-burns
     #[arg(short = 'a', long)]
     animate: Option<String>,
 
@@ -82,7 +83,7 @@ fn main() -> image::ImageResult<()> {
     if let Some(ref effect_name) = args.animate {
         let effect = animator::Effect::from_str(effect_name).unwrap_or_else(|| {
             eprintln!(
-                "Unknown animation effect: {}. Valid: dissolve-in, dissolve-out, swirl-in, swirl-out, ken-burns",
+                "Unknown animation effect: {}. Valid: dissolve-in, dissolve-out, swirl-in, swirl-out, whirl-in, whirl-out, ken-burns",
                 effect_name
             );
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ struct Args {
     #[arg(short, long)]
     invert: bool,
 
+    /// Trim empty borders (transparent, solid color) from the image
+    #[arg(short = 't', long)]
+    trim: bool,
+
     /// Characters used to render the image, from transparent to opaque.
     /// Built-in charsets: block, blocks, braille, chinese, default, dense,
     /// emoji, hybrid, russian, slight, stipple
@@ -58,7 +62,7 @@ fn main() -> image::ImageResult<()> {
             colored: args.colored,
             background: args.background,
             invert: args.invert,
-            trim: false,
+            trim: args.trim,
             charset,
         },
     )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use std::io;
 
 use clap::Parser;
-use rascii_art::{
-    charsets,
-    RenderOptions,
-};
+use rascii_art::{charsets, RenderOptions};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Parser)]
@@ -36,7 +33,8 @@ struct Args {
     invert: bool,
 
     /// Characters used to render the image, from transparent to opaque.
-    /// Built-in charsets: block, emoji, default, russian, slight
+    /// Built-in charsets: block, blocks, braille, chinese, default, dense,
+    /// emoji, hybrid, russian, slight, stipple
     #[arg(short = 'C', long, default_value = "default")]
     charset: String,
 }
@@ -60,6 +58,7 @@ fn main() -> image::ImageResult<()> {
             colored: args.colored,
             background: args.background,
             invert: args.invert,
+            trim: false,
             charset,
         },
     )?;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -9,6 +9,7 @@ pub struct RenderOptions<'a> {
     pub colored: bool,
     pub background: bool,
     pub invert: bool,
+    pub trim: bool,
     pub charset: &'a [&'a str],
 }
 
@@ -51,6 +52,12 @@ impl<'a> RenderOptions<'a> {
         self
     }
 
+    /// Set whether to trim empty borders from the image.
+    pub fn trim(mut self, trim: bool) -> Self {
+        self.trim = trim;
+        self
+    }
+
     /// Set the charset to use for the rendered image.
     pub fn charset(mut self, charset: &'a [&'a str]) -> Self {
         self.charset = charset;
@@ -66,6 +73,7 @@ impl Default for RenderOptions<'_> {
             colored: false,
             background: false,
             invert: false,
+            trim: false,
             charset: charsets::DEFAULT,
         }
     }

--- a/src/trim.rs
+++ b/src/trim.rs
@@ -1,0 +1,102 @@
+use image::{DynamicImage, GenericImageView};
+
+const VARIANCE_EPSILON: f64 = 30.0;
+
+fn grayscale(r: u8, g: u8, b: u8) -> f64 {
+    0.299 * r as f64 + 0.587 * g as f64 + 0.114 * b as f64
+}
+
+fn row_variance(image: &DynamicImage, y: u32) -> f64 {
+    let w = image.width();
+    if w == 0 {
+        return 0.0;
+    }
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    let mut count = 0u32;
+    for x in 0..w {
+        let px = image.get_pixel(x, y);
+        if px[3] == 0 {
+            continue;
+        }
+        let g = grayscale(px[0], px[1], px[2]);
+        sum += g;
+        sum_sq += g * g;
+        count += 1;
+    }
+    if count == 0 {
+        return 0.0;
+    }
+    let mean = sum / count as f64;
+    sum_sq / count as f64 - mean * mean
+}
+
+fn col_variance(image: &DynamicImage, x: u32) -> f64 {
+    let h = image.height();
+    if h == 0 {
+        return 0.0;
+    }
+    let mut sum = 0.0;
+    let mut sum_sq = 0.0;
+    let mut count = 0u32;
+    for y in 0..h {
+        let px = image.get_pixel(x, y);
+        if px[3] == 0 {
+            continue;
+        }
+        let g = grayscale(px[0], px[1], px[2]);
+        sum += g;
+        sum_sq += g * g;
+        count += 1;
+    }
+    if count == 0 {
+        return 0.0;
+    }
+    let mean = sum / count as f64;
+    sum_sq / count as f64 - mean * mean
+}
+
+pub fn trim_image(image: &DynamicImage) -> DynamicImage {
+    let (w, h) = (image.width(), image.height());
+    if w == 0 || h == 0 {
+        return image.clone();
+    }
+
+    let mut top = 0u32;
+    for y in 0..h {
+        if row_variance(image, y) >= VARIANCE_EPSILON {
+            break;
+        }
+        top = y + 1;
+    }
+
+    let mut bottom = h;
+    for y in (0..h).rev() {
+        if row_variance(image, y) >= VARIANCE_EPSILON {
+            break;
+        }
+        bottom = y;
+    }
+
+    let mut left = 0u32;
+    for x in 0..w {
+        if col_variance(image, x) >= VARIANCE_EPSILON {
+            break;
+        }
+        left = x + 1;
+    }
+
+    let mut right = w;
+    for x in (0..w).rev() {
+        if col_variance(image, x) >= VARIANCE_EPSILON {
+            break;
+        }
+        right = x;
+    }
+
+    if top >= bottom || left >= right {
+        return image.clone();
+    }
+
+    image.crop_imm(left, top, right - left, bottom - top)
+}

--- a/tests/trim.rs
+++ b/tests/trim.rs
@@ -1,0 +1,91 @@
+use image::{DynamicImage, Rgba, RgbaImage};
+use rascii_art::RenderOptions;
+
+fn make_bordered_image(content_w: u32, content_h: u32, border: u32, bg: Rgba<u8>) -> DynamicImage {
+    let total_w = content_w + border * 2;
+    let total_h = content_h + border * 2;
+    let mut img = RgbaImage::from_pixel(total_w, total_h, bg);
+    for y in border..(border + content_h) {
+        for x in border..(border + content_w) {
+            let r = ((x * 37 + y * 53) % 256) as u8;
+            let g = ((x * 59 + y * 31) % 256) as u8;
+            let b = ((x * 43 + y * 47) % 256) as u8;
+            img.put_pixel(x, y, Rgba([r, g, b, 255]));
+        }
+    }
+    DynamicImage::ImageRgba8(img)
+}
+
+#[test]
+fn trim_removes_black_border() {
+    let img = make_bordered_image(20, 20, 10, Rgba([0, 0, 0, 255]));
+    let mut output = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut output,
+        &RenderOptions::new().width(40).trim(true),
+    )
+    .unwrap();
+    let mut no_trim_output = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut no_trim_output,
+        &RenderOptions::new().width(40).trim(false),
+    )
+    .unwrap();
+    let trim_blank = output.lines().filter(|l| l.trim().is_empty()).count();
+    let no_trim_blank = no_trim_output
+        .lines()
+        .filter(|l| l.trim().is_empty())
+        .count();
+    assert!(
+        trim_blank < no_trim_blank,
+        "trim should remove empty border rows"
+    );
+}
+
+#[test]
+fn trim_preserves_content_only_image() {
+    let img = make_bordered_image(20, 20, 0, Rgba([0, 0, 0, 255]));
+    let mut trimmed = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut trimmed,
+        &RenderOptions::new().width(20).trim(true),
+    )
+    .unwrap();
+    let mut untrimmed = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut untrimmed,
+        &RenderOptions::new().width(20).trim(false),
+    )
+    .unwrap();
+    assert_eq!(trimmed.lines().count(), untrimmed.lines().count());
+}
+
+#[test]
+fn trim_handles_fully_transparent_border() {
+    let img = make_bordered_image(20, 20, 10, Rgba([0, 0, 0, 0]));
+    let mut output = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut output,
+        &RenderOptions::new().width(40).trim(true),
+    )
+    .unwrap();
+    assert!(!output.is_empty());
+}
+
+#[test]
+fn trim_handles_solid_image() {
+    let img = DynamicImage::ImageRgba8(RgbaImage::from_pixel(20, 20, Rgba([50, 50, 50, 255])));
+    let mut output = String::new();
+    rascii_art::render_image_to(
+        &img,
+        &mut output,
+        &RenderOptions::new().width(20).trim(true),
+    )
+    .unwrap();
+    assert!(!output.is_empty());
+}


### PR DESCRIPTION
## Summary

- **5 new charsets**: `dense` (95-level all-ASCII), `braille` (dot-matrix), `blocks` (geometric pixel-art), `stipple` (pointillist), `hybrid` (braille+blocks HDR mix)
- **`--trim`**: Variance-based border cropping that detects and removes empty edges (solid color, transparent) before rendering, so content fills the available space
- **7 animation effects** via `--animate <effect>`: `dissolve-in`, `dissolve-out`, `swirl-in`, `swirl-out`, `whirl-in`, `whirl-out`, `ken-burns` — retro BBS-style terminal animations using ANSI cursor positioning
- **`--duration <seconds>`**: Control animation timing (default 3s)
- **Animated GIF playback**: Auto-detected by `.gif` extension, decodes all frames and plays in terminal with proper frame delays

## Test plan

- [x] 4 integration tests for trim (black border, no border, transparent border, solid image)
- [ ] Manual: `rascii image.png --trim` removes black borders on Archivium logo
- [ ] Manual: `rascii image.png -C dense -c` renders with 95-level charset
- [ ] Manual: `rascii image.png --trim -a whirl-out -c -d 3` plays vortex animation
- [ ] Manual: `rascii animated.gif -c -w 40` plays animated GIF in terminal

## Summary by Sourcery

Add image trimming, extended charsets, terminal animations, and animated GIF playback to the ASCII renderer and CLI.

New Features:
- Add a trim option to remove low-variance or empty borders before rendering images.
- Introduce five additional built-in charsets (blocks, braille, hybrid, dense, stipple) and wire them into charset selection.
- Add a terminal animation system with multiple effects selectable via CLI flags and configurable duration.
- Support animated GIF playback in the terminal by decoding frames to grids and looping them with per-frame delays.

Enhancements:
- Extend the rendering pipeline with a cell grid abstraction that can be reused for animations and GIF playback.
- Expose helper functions for trimming images and rendering to grids for reuse by callers.

Build:
- Add the rand crate dependency for randomized animation effects.

Tests:
- Add integration tests validating trim behavior for bordered, borderless, transparent, and solid images.